### PR TITLE
feat: ignore css-modules `:global` selector

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -46,6 +46,12 @@
     "string-quotes": "single",
     "value-no-vendor-prefix": true,
     "font-family-no-missing-generic-family-keyword": null,
-    "no-descending-specificity": null
+    "no-descending-specificity": null,
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        "ignorePseudoClasses": ["global"]
+      }
+    ]
   }
 }


### PR DESCRIPTION
We need to ignore `:global` pseudo selector introduced by CSS modules.
Reference: https://stylelint.io/user-guide/configure#rules