### PR TITLE
Allow px for margin, padding, height, & width

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -17,8 +17,8 @@
       "/^border(?!.*-radius$)/": ["px", "%"],
       "/^border-radius/": ["px", "rem", "%"],
       "/^box-shadow": ["px"],
-      "/^margin/": ["rem"],
-      "/^padding/": ["rem"],
+      "/^margin/": ["rem", "px"],
+      "/^padding/": ["rem", "px"],
       "font-size": ["rem", "em"],
       "height": ["rem", "%", "vh"],
       "width": ["rem", "%", "vw"]

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -20,8 +20,8 @@
       "/^margin/": ["rem", "px"],
       "/^padding/": ["rem", "px"],
       "font-size": ["rem", "em"],
-      "height": ["rem", "%", "vh"],
-      "width": ["rem", "%", "vw"]
+      "height": ["rem", "%", "vh", "px"],
+      "width": ["rem", "%", "vw", "px"]
     },
     "max-empty-lines": 1,
     "no-duplicate-selectors": true,


### PR DESCRIPTION
Forcing font-based sizing onto non-font-based elements is a mistake.

This article does a great job of explaining why: https://medium.com/@sascha.wolff/dont-use-rem-em-for-paddings-margins-and-more-94e19026b000

This PR adds `px` as an available unit for margin, padding, height, & width.

I also believe we should refactor `rems` to `px` in the rest of the codebase and update this rule to enforce `px` only, but we can address that later if everyone agrees with me here.

Slack conversation here https://sourcegraph.slack.com/archives/C0HMGV90V/p1661848404811549