### PR TITLE
Add min/max width/height to the unit-allowed-list

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -21,7 +21,11 @@
       "/^padding/": ["rem", "px"],
       "font-size": ["rem", "em"],
       "height": ["rem", "%", "vh", "px"],
-      "width": ["rem", "%", "vw", "px"]
+      "max-height": ["rem", "%", "vh", "px"],
+      "min-height": ["rem", "%", "vh", "px"],
+      "width": ["rem", "%", "vw", "px"],
+      "max-width": ["rem", "%", "vw", "px"],
+      "min-width": ["rem", "%", "vw", "px"]
     },
     "max-empty-lines": 1,
     "no-duplicate-selectors": true,


### PR DESCRIPTION
Just update the unit-allowed list with max-width min-width max-height min-height to avoid unnecessary stylelint disables. 